### PR TITLE
Add missing trailing slash to base url

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -8,7 +8,7 @@ var xtend = require('xtend');
 
 var oauth = require('./oauth');
 
-var baseURL = 'http://api.parsely.com/v2';
+var baseURL = 'http://api.parsely.com/v2/';
 
 /**
  * Makes the acutal request


### PR DESCRIPTION
Omitting the trailing slash causes [`url.resolve`](nodejs.org/api/url.html#url_url_resolve_from_to) to treat `v2` in `http://api.parsely.com/v2/` as a leaf and resolves non-absolute paths from the root, e.g. `/analytics/posts` instead of `/v2/analytics/posts`.