### PR TITLE
Fix npm script in pre-commit trigger script

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-npm run precommit
+npm run pre-commit


### PR DESCRIPTION
The npm script name is misspelled in the hook script.